### PR TITLE
Queue driven CSV Creation

### DIFF
--- a/src/CoandaCMS/CoandaWebForms/Queue/CreateCsv.php
+++ b/src/CoandaCMS/CoandaWebForms/Queue/CreateCsv.php
@@ -1,0 +1,118 @@
+<?php namespace CoandaCMS\CoandaWebForms\Queue;
+
+class CreateCsv {
+
+    /**
+     * @var 
+     */
+    protected $job;
+
+    /**
+     * @var \CoandaCMS\CoandaWebForms\Repositories\WebFormsRepositoryInterface
+     */
+    protected $formsRepository;
+
+    /**
+     * @var \CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models\WebFormDownload
+     */
+    protected $download;
+
+    /**
+     * @var  \CoandaCMS\CoandaWebForms\Exporters\CsvExporter $exporter
+     */
+    protected $exporter;
+
+    /**
+     * __construct
+     * 
+     * @param \CoandaCMS\CoandaWebForms\Exporters\CsvExporter $exporter
+     */
+    public function __construct(\CoandaCMS\CoandaWebForms\Repositories\WebFormsRepositoryInterface $formsRepository, \CoandaCMS\CoandaWebForms\Exporters\CsvExporter $exporter) {
+        $this->formsRepository = $formsRepository;
+        $this->exporter = $exporter;
+    }
+
+    /**
+     * Execute the queue job.
+     *
+     * @return void
+     */
+    public function fire($job, $data) {
+        $this->job = $job;
+        $this->download = $this->formsRepository->getDownload($data['id']);
+
+        if ($this->download) {
+            $this->run();
+        }
+
+        $this->job->delete();
+    }
+
+    /**
+     * Run this job
+     * 
+     * @return void
+     */
+    protected function run() {
+        $this->setStatusToInProgress()->createCsvFile();
+    }
+
+    /**
+     * Sets the status of the WebFormDownload to in progress.
+     *
+     * @return CreateCsv $this
+     */
+    protected function setStatusToInProgress() {
+        $this->download->status = 1;
+        $this->download->save();
+
+        return $this;
+    }
+
+    /**
+     * Sets the status of the WebFormDownload to complete
+     * and adds the CSV's filename.
+     * 
+     * @param  string $file_name
+     */
+    protected function setStatusToComplete($file_name) {
+        $this->download->filename = $file_name;
+        $this->download->status = 2;
+        $this->download->save();
+
+        return $this;
+    }
+
+    /**
+     * Sets the status to failed. 
+     *
+     * @return 
+     */
+    protected function setStatusToFailed() {
+        $this->download->status = -1;
+        $this->download->save();
+
+        return $this;
+    }
+
+    /**
+     * Creates the CSV file using the CsvExporter
+     * 
+     * @return
+     */
+    protected function createCsvFile() {
+        $form = $this->download->form;
+        $file_name = $this->exporter->exportToFile($form, false, [], $this->download->id);
+
+        if ($file_name) {
+            $this->setStatusToComplete($file_name);
+
+            return;
+        }
+
+        $this->setStatusToFailed();
+
+        return;
+    }
+
+}

--- a/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/Submission.php
+++ b/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/Submission.php
@@ -54,22 +54,6 @@ class Submission extends Eloquent {
      */
     public function fieldsForHeadings($headings)
     {
-        $fields = [];
-
-        foreach ($headings as $heading)
-        {
-            $field = $this->fields()->whereLabel($heading)->first();
-
-            if ($field)
-            {
-                $fields[] = $field;
-            }
-            else
-            {
-                $fields[] = false;
-            }
-        }
-
-        return $fields;
+        return $this->fields()->whereIn('label', $headings)->get();
     }
 }

--- a/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/WebForm.php
+++ b/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/WebForm.php
@@ -1,6 +1,8 @@
 <?php namespace CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models;
 
-use Eloquent, Coanda;
+use Carbon\Carbon;
+use Coanda;
+use Eloquent;
 
 class WebForm extends Eloquent {
 
@@ -28,6 +30,7 @@ class WebForm extends Eloquent {
             SubmissionField::join('coanda_webformsubmissions', 'coanda_webformsubmissions.id', '=', 'coanda_webformsubmissionfields.submission_id')->where('coanda_webformsubmissions.form_id', '=', $form->id)->delete();
             $form->submissions()->delete();
 
+            $form->downloads()->delete();
         });
     }
 
@@ -45,6 +48,26 @@ class WebForm extends Eloquent {
     public function submissions()
     {
         return $this->hasMany('CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models\Submission', 'form_id')->orderBy('created_at', 'desc');
+    }
+    
+    /**
+     * Returns the downloads collection
+     * 
+     * @return mixed
+     */
+    public function downloads()
+    {
+        return $this->hasMany('CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models\WebFormDownload', 'webform_id')->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Returns a single download
+     * 
+     * @return mixed
+     */
+    public function download()
+    {
+        return $this->downloads()->first();
     }
 
     /**

--- a/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/WebFormDownload.php
+++ b/src/CoandaCMS/CoandaWebForms/Repositories/Eloquent/Models/WebFormDownload.php
@@ -1,0 +1,151 @@
+<?php namespace CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models;
+
+use Carbon\Carbon;
+use Coanda;
+use Eloquent;
+use Illuminate\Database\Eloquent\Model;
+use Queue;
+
+/**
+ * Class WebFormDownload
+ * @package CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models
+ */
+class WebFormDownload extends Model {
+
+    /**
+     * @var array
+     */
+    protected $fillable = ['webform_id', 'status', 'status_percentage', 'filename'];
+
+    /**
+     * @var string
+     */
+    protected $table = 'coanda_webform_downloads';
+
+    /**
+     * 
+     * @return void
+     */
+    public static function boot()
+    {
+
+        parent::boot();
+    }
+
+    /**
+     * @param array $options
+     */
+    public function save(array $options = [])
+    {
+        
+        parent::save($options);
+    }
+
+    public function delete(array $options = [])
+    {
+
+        parent::delete($options);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function form()
+    {
+        return $this->belongsTo('CoandaCMS\CoandaWebForms\Repositories\Eloquent\Models\WebForm', 'webform_id');
+    }
+
+    /**
+     * Add a task to the queue for the webform
+     * submissions list CSV to be created, and save
+     * this WebFormDownload isntance to the database.
+     * 
+     * @return boolean
+     */
+    public function queue()
+    {
+        $this->save();
+
+        Queue::push('CoandaCMS\CoandaWebForms\Queue\CreateCsv', $this);
+    }
+
+    /**
+     * Has the queue task been run and has it completed?
+     * 
+     * @return boolean
+     */
+    public function queueTaskHasRun()
+    {
+        if ($this->status <= 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * How old is the file?
+     * 
+     * @return mixed Returns false if the file doesn't exist yet
+     */
+    public function age()
+    {
+        if (!$this->available()) {
+            return false;
+        }
+
+        return Carbon::parse( $this->updated_at )->diffForHumans();
+    }
+
+    /**
+     * Returns true if the file exists. 
+     * First checks if the task is run, since there's not point
+     * checking the filesystem if the task hasn't run yet!
+     * 
+     * @return boolean
+     */
+    public function available()
+    {
+        if (!$this->queueTaskHasRun()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Accessor for status_percentage
+     *
+     * Takes the decimal value from the status_percentage
+     * column and appends the percentage (%) symbol.
+     *
+     * @return  string
+     */
+    public function getStatusPercentageAttribute($value)
+    {
+        return round($value) . '%';
+    }
+
+    /**
+     * Mutator for status_percentage
+     *
+     * Takes the calculated percentage and converts it
+     * to the correct format for the database:
+     *     decimal(3,0)
+     * 
+     * @param [type] $value [description]
+     */
+    public function setStatusPercentageAttribute($value)
+    {
+        if ($value < 0) {
+            $value = 0;
+        }
+
+        if ($value > 100) {
+            $value = 100;
+        }
+
+        $this->attributes['status_percentage'] = round($value);
+    }
+
+}

--- a/src/CoandaCMS/CoandaWebForms/Repositories/WebFormsRepositoryInterface.php
+++ b/src/CoandaCMS/CoandaWebForms/Repositories/WebFormsRepositoryInterface.php
@@ -63,4 +63,14 @@ interface WebFormsRepositoryInterface {
      * @return mixed
      */
     public function getSubmissions($form_id, $offset, $limit, $from, $to);
+
+    /**
+     * @param array $data
+     */
+    public function createDownload($data);
+
+    /**
+     * @param int $download_id
+     */
+    public function getDownload($download_id);
 }

--- a/src/CoandaCMS/CoandaWebForms/WebFormsModuleProvider.php
+++ b/src/CoandaCMS/CoandaWebForms/WebFormsModuleProvider.php
@@ -47,6 +47,10 @@ class WebFormsModuleProvider implements \CoandaCMS\Coanda\CoandaModuleProvider {
                 'name' => 'Download',
                 'options' => []
             ],
+            'queue' => [
+                'name' => 'Queue',
+                'options' => []
+            ],
         ];
 
 		$coanda->addModulePermissions('webforms', 'Web forms', $permissions);

--- a/src/migrations/2015_06_23_155546_create_webform_downloads_table.php
+++ b/src/migrations/2015_06_23_155546_create_webform_downloads_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateWebformDownloadsTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        Schema::create('coanda_webform_downloads', function ($table) {
+
+            $table->increments('id');
+            $table->integer('webform_id');
+            $table->integer('status');
+            $table->string('filename');
+
+            $table->timestamps();
+
+        });
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        Schema::drop('coanda_webform_downloads');
+    }
+
+}

--- a/src/migrations/2015_06_24_135429_WebFormDownloadStatusPercentageColumn.php
+++ b/src/migrations/2015_06_24_135429_WebFormDownloadStatusPercentageColumn.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class WebFormDownloadStatusPercentageColumn extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('coanda_webform_downloads', function($table)
+		{
+		    $table->decimal('status_percentage', 3, 0);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('coanda_webform_downloads', function($table)
+		{
+			$table->dropColumn('status_percentage');
+		});
+	}
+
+}


### PR DESCRIPTION
This adds functionality which will allow the admin user(s) to request a download to be created of a forms submissions, rather than attempting to generate the CSV on-the-fly.

This requires a queue driver and as such, the 'request download' buttons will not appear (and the functionality will not be available) unless a queue driver is detected. \* This will not work with the Laravel default queue driver of `sync` *

Requesting a download is also only possible on forms  which have more than 1000 submissions.

Upon requesting a download, the job is added to the queue and the requested download to the web form database table `coanda_webforms_downloads` (which has an associated model WebFormDownlaod). Since this new table is required, you will need to run the migration `php artisan migrate --package=coandacms=coanda-web-forms`

Once a download has been requested, an AJAX GET request is fired off every 2.5 seconds until the download is available. Each GET request responds with a percentage of the download which has been created, which is then updated in the download button to give some valuable feedback to the admin user(s).

Files created are stored in the /app/storage/webformsubmissions/ directory.

Once a download has been created and stored, upon revisiting the form in the admin panel the download is still available and includes a `badge` with how recently the download was created.

Besides this is a button to re-request the download which will update it with all of the latest submissions (at which point the old download is no longer accessible from an administrators perspective - but it still exists in the filesystem).
